### PR TITLE
Fix #2, add micro, and add "second best editor"

### DIFF
--- a/choose.js
+++ b/choose.js
@@ -74,125 +74,155 @@ var candidates = {
         link: "https://kde.org/applications/utilities/kwrite",
         score: 0,
         ineligible: false
-    }
+    },
 };
 
 // The list of questions to ask the user. Each question has a prompt text
 // followed by a list of options that the user may select and use. Options
-// have a text label, a list of candidates they benefit, and a list of
-// candidates that are registered ineligible.
+// have a text label, a list of candidates they benefit/disadvantages,
+// how important that question is (added score) for both advantages and
+// disadvantages, and a list of candidates that are registered ineligible.
 var questions = [
     {
         text: "Would you like to work in the Terminal, or in a GUI?",
+		bimportance: 0.8,
+		dimportance: 0.6,
         options: [
             {
                 text: "Terminal",
                 benefits: ["nano", "vim"],
-                ineligible: ["kwrite", "gedit", "spacemacs", "atom", "gvim"]
+				disadvantages: ["kwrite", "gedit", "spacemacs", "atom", "emacs"],
+                ineligible: ["gvim"]
             },
             {
                 text: "GUI",
                 benefits: ["atom", "kwrite", "gedit", "spacemacs", "emacs", "gvim"],
-                ineligible: ["nano", "vim"]
+				disadvantages: ["nano"],
+                ineligible: ["vim"]
             },
             {
                 text: "Either One",
                 benefits: [],
+				disadvantages: [],
                 ineligible: []
             }
         ]
     },
     {
         text: "Intuitive or Advanced Controls?",
+		bimportance: 1,
+		dimportance: 1,
         options: [
             {
                 text: "Intuitive",
                 benefits: ["nano", "atom", "gedit", "kwrite"],
-                ineligible: ["vim", "gvim"]
+				disadvantages: ["vim", "gvim"],
+                ineligible: []
             },
             {
                 text: "Advanced",
                 benefits: ["emacs", "vim", "gvim", "spacemacs"],
-                ineligible: ["nano", "gedit"]
+				disadvantages: ["nano", "gedit"],
+                ineligible: []
             },
             {
                 text: "Whichever",
                 benefits: [],
+				disadvantages: [],
                 ineligible: []
             }
         ]
     },
     {
         text: "Do you need advanced features like split views?",
+		bimportance: 1,
+		dimportance: 1.5,
         options: [
             {
                 text: "Definitely!",
                 benefits: ["vim", "gvim", "emacs", "spacemacs", "atom"],
+				disadvantages: [],
                 ineligible: ["nano", "gedit", "kwrite"]
             },
             {
                 text: "Not Really.",
                 benefits: [],
+				disadvantages: [],
                 ineligible: []
             }
         ]
     },
     {
         text: "Do you prefer vim or emacs's editing style?",
+		bimportance: 1.5,
+		dimportance: 2,
         options: [
             {
                 text: "Vim all the way!",
                 benefits: ["vim", "gvim", "spacemacs"],
-                ineligible: ["emacs", "atom", "gedit", "kwrite", "nano"]
+				disadvantages: ["emacs", "atom", "gedit", "kwrite", "nano"],
+                ineligible: []
             },
             {
                 text: "Emacs forever!",
                 benefits: ["emacs", "spacemacs"],
-                ineligible: ["vim", "gvim", "atom", "gedit", "kwrite", "nano"]
+				disadvantages: ["vim", "gvim", "atom", "gedit", "kwrite", "nano"],
+                ineligible: []
             },
             {
                 text: "Neither!",
                 benefits: ["atom", "gedit", "kwrite", "nano"],
-                ineligible: ["emacs", "vim", "gvim", "spacemacs"]
+				disadvantages: ["emacs", "vim", "gvim", "spacemacs"],
+                ineligible: []
             },
             {
                 text: "I Don't Know!",
                 benefits: ["spacemacs", "nano", "gedit", "kwrite", "atom"],
+				disadvantages: [],
                 ineligible: []
             }
         ]
     },
     {
         text: "Want something nice and stable or modern?",
+		bimportance: 1,
+		dimportance: 0.75,
         options: [
             {
                 text: "Stable!",
-                benefits: ["vim", "gvim", "emacs"],
-                ineligible: ["atom", "gedit", "kwrite", "spacemacs"]
+                benefits: ["vim", "gvim", "emacs", "nano"],
+				disadvantages: ["atom", "gedit", "kwrite", "spacemacs"],
+                ineligible: []
             },
             {
                 text: "Modern!",
                 benefits: ["atom", "spacemacs"],
-                ineligible: ["vim", "gvim", "emacs"]
+				disadvantages: ["vim", "gvim", "emacs"],
+                ineligible: []
             },
             {
                 text: "Either One!",
                 benefits: [],
+				disadvantages: [],
                 ineligible: []
             }
         ]
     },
     {
         text: "Want to theme and customize your editor?",
+		bimportance: 1,
+		dimportance: 1.5,
         options: [
             {
                 text: "Of course!",
                 benefits: ["spacemacs", "atom", "vim", "gvim", "emacs", "kwrite"],
-                ineligible: ["nano"]
+				disadvantages: ["nano"],
+                ineligible: []
             },
             {
                 text: "Doesn't matter!",
                 benefits: [],
+				disadvantages: [],
                 ineligible: []
             }
         ]
@@ -208,12 +238,14 @@ var displayResults = function () {
     }).filter(function (candidate) {
         return !candidate.ineligible;
     });
+	
+	console.log(candidateArray)
 
     // Sort candidates by score.
     candidateArray.sort(function (a, b) {
         if (a.score === b.score) return 0;
-        if (a.score > b.score) return 1;
-        if (a.score < b.score) return -1;
+        if (a.score > b.score) return -1; //I dont know why, but I had to reverse this, as the
+        if (a.score < b.score) return 1;  //picker picked the editor with the lowest(!) score.
     });
 
     if (!candidateArray[0]) {
@@ -253,14 +285,23 @@ var questionPrompt = function () {
         answerButton.onclick = function () {
             // Increase score of benefiting candidates.
             answer.benefits.forEach(function(benefits) {
-                candidates[benefits].score++;
+                candidates[benefits].score += questions[question].bimportance;
+				console.log(candidates[benefits].name, candidates[benefits].score)
+            });
+			
+			answer.disadvantages.forEach(function(disadvantages) {
+                candidates[disadvantages].score -= questions[question].dimportance;
+				console.log(candidates[disadvantages].name, candidates[disadvantages].score)
             });
 
             // Mark newly ineligible candidates.
             answer.ineligible.forEach(function(ineligible) {
                 candidates[ineligible].ineligible = true;
+				console.log(candidates[ineligible].name, candidates[ineligible].ineligible)
             });
-
+			
+			console.log("") //Print newline for making debug logs make more sense.
+			
             // Prompt for the next question.
             questionPrompt();
         };

--- a/choose.js
+++ b/choose.js
@@ -19,7 +19,10 @@ var dom = {
     startButton: document.getElementById("start"),
 
     // The query area containing the quiz.
-    query: document.getElementById("query")
+    query: document.getElementById("query"),
+	
+	// Second best editor
+	namesb: document.getElementById("namesb")
 };
 
 // A list of candidates for editor to be recommended.
@@ -244,8 +247,6 @@ var displayResults = function () {
     }).filter(function (candidate) {
         return !candidate.ineligible;
     });
-	
-	console.debug(candidateArray)
 
     // Sort candidates by score.
     candidateArray.sort(function (a, b) {
@@ -261,9 +262,11 @@ var displayResults = function () {
         };
     }
 
-    // Show the ideal editor name and link.
+    // Show the ideal editor name and link, followed by second best editor.
     dom.question.innerHTML = candidateArray[0].name;
     dom.question.href = candidateArray[0].link;
+	dom.namesb.innerHTML = candidateArray[1].name;
+    dom.namesb.href = candidateArray[1].link;
 
     // Classify the quiz as finished / link-mode.
     dom.query.classList.add("link");
@@ -292,7 +295,7 @@ var questionPrompt = function () {
             // Increase score of benefiting candidates.
             answer.benefits.forEach(function(benefits) {
                 candidates[benefits].score += questions[question].bimportance;
-				console.debug(candidates[benefits].name, candidates[benefits].score)
+				console.debug(candidates[benefits].name, candidates[benefits].score) //Print debug logs
             });
 			
 			answer.disadvantages.forEach(function(disadvantages) {
@@ -306,7 +309,7 @@ var questionPrompt = function () {
 				console.debug(candidates[ineligible].name, candidates[ineligible].ineligible)
             });
 			
-			console.debug("") //Print newline for making debug logs make more sense.
+			console.debug("") //Print newline for separating debug logs
 			
             // Prompt for the next question.
             questionPrompt();

--- a/choose.js
+++ b/choose.js
@@ -75,6 +75,12 @@ var candidates = {
         score: 0,
         ineligible: false
     },
+	micro: {
+        name: "micro",
+        link: "https://micro-editor.github.io/",
+        score: 0,
+        ineligible: false
+    }
 };
 
 // The list of questions to ask the user. Each question has a prompt text
@@ -90,7 +96,7 @@ var questions = [
         options: [
             {
                 text: "Terminal",
-                benefits: ["nano", "vim"],
+                benefits: ["nano", "vim", "micro"],
 				disadvantages: ["kwrite", "gedit", "spacemacs", "atom", "emacs"],
                 ineligible: ["gvim"]
             },
@@ -115,14 +121,14 @@ var questions = [
         options: [
             {
                 text: "Intuitive",
-                benefits: ["nano", "atom", "gedit", "kwrite"],
+                benefits: ["nano", "atom", "gedit", "kwrite", "micro"],
 				disadvantages: ["vim", "gvim"],
                 ineligible: []
             },
             {
                 text: "Advanced",
                 benefits: ["emacs", "vim", "gvim", "spacemacs"],
-				disadvantages: ["nano", "gedit"],
+				disadvantages: ["nano", "gedit", "micro"],
                 ineligible: []
             },
             {
@@ -140,7 +146,7 @@ var questions = [
         options: [
             {
                 text: "Definitely!",
-                benefits: ["vim", "gvim", "emacs", "spacemacs", "atom"],
+                benefits: ["vim", "gvim", "emacs", "spacemacs", "atom", "micro"],
 				disadvantages: [],
                 ineligible: ["nano", "gedit", "kwrite"]
             },
@@ -160,24 +166,24 @@ var questions = [
             {
                 text: "Vim all the way!",
                 benefits: ["vim", "gvim", "spacemacs"],
-				disadvantages: ["emacs", "atom", "gedit", "kwrite", "nano"],
+				disadvantages: ["emacs", "atom", "gedit", "kwrite", "nano", "micro"],
                 ineligible: []
             },
             {
                 text: "Emacs forever!",
                 benefits: ["emacs", "spacemacs"],
-				disadvantages: ["vim", "gvim", "atom", "gedit", "kwrite", "nano"],
+				disadvantages: ["vim", "gvim", "atom", "gedit", "kwrite", "nano", "micro"],
                 ineligible: []
             },
             {
                 text: "Neither!",
-                benefits: ["atom", "gedit", "kwrite", "nano"],
+                benefits: ["atom", "gedit", "kwrite", "nano", "micro"],
 				disadvantages: ["emacs", "vim", "gvim", "spacemacs"],
                 ineligible: []
             },
             {
                 text: "I Don't Know!",
-                benefits: ["spacemacs", "nano", "gedit", "kwrite", "atom"],
+                benefits: ["spacemacs", "nano", "gedit", "kwrite", "atom", "micro"],
 				disadvantages: [],
                 ineligible: []
             }
@@ -191,12 +197,12 @@ var questions = [
             {
                 text: "Stable!",
                 benefits: ["vim", "gvim", "emacs", "nano"],
-				disadvantages: ["atom", "gedit", "kwrite", "spacemacs"],
+				disadvantages: ["atom", "gedit", "kwrite", "spacemacs", "micro"],
                 ineligible: []
             },
             {
                 text: "Modern!",
-                benefits: ["atom", "spacemacs"],
+                benefits: ["atom", "spacemacs", "micro"],
 				disadvantages: ["vim", "gvim", "emacs"],
                 ineligible: []
             },
@@ -215,7 +221,7 @@ var questions = [
         options: [
             {
                 text: "Of course!",
-                benefits: ["spacemacs", "atom", "vim", "gvim", "emacs", "kwrite"],
+                benefits: ["spacemacs", "atom", "vim", "gvim", "emacs", "kwrite", "micro"],
 				disadvantages: ["nano"],
                 ineligible: []
             },

--- a/choose.js
+++ b/choose.js
@@ -245,7 +245,7 @@ var displayResults = function () {
         return !candidate.ineligible;
     });
 	
-	console.log(candidateArray)
+	console.debug(candidateArray)
 
     // Sort candidates by score.
     candidateArray.sort(function (a, b) {
@@ -292,21 +292,21 @@ var questionPrompt = function () {
             // Increase score of benefiting candidates.
             answer.benefits.forEach(function(benefits) {
                 candidates[benefits].score += questions[question].bimportance;
-				console.log(candidates[benefits].name, candidates[benefits].score)
+				console.debug(candidates[benefits].name, candidates[benefits].score)
             });
 			
 			answer.disadvantages.forEach(function(disadvantages) {
                 candidates[disadvantages].score -= questions[question].dimportance;
-				console.log(candidates[disadvantages].name, candidates[disadvantages].score)
+				console.debug(candidates[disadvantages].name, candidates[disadvantages].score)
             });
 
             // Mark newly ineligible candidates.
             answer.ineligible.forEach(function(ineligible) {
                 candidates[ineligible].ineligible = true;
-				console.log(candidates[ineligible].name, candidates[ineligible].ineligible)
+				console.debug(candidates[ineligible].name, candidates[ineligible].ineligible)
             });
 			
-			console.log("") //Print newline for making debug logs make more sense.
+			console.debug("") //Print newline for making debug logs make more sense.
 			
             // Prompt for the next question.
             questionPrompt();

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
                 <button id="start">I'm Ready!</button>
             </div>
 			<br>
-			<div class="captionsb">Second best:</div>
+			<div class="caption">Second best:</div>
 			<a id="namesb" href="#">None!</a>
-			<div class="captionsb">Click to read more</div>
+			<div class="caption">Click to read more</div>
         </div>
         <div id="about">
             A half-finished project by <a href="http://tague.me">Ethan McTague</a> |

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
             <div id="answers">
                 <button id="start">I'm Ready!</button>
             </div>
+			<br>
+			<div class="captionsb">Second best:</div>
+			<a id="namesb" href="#">None!</a>
+			<div class="captionsb">Click to read more</div>
         </div>
         <div id="about">
             A half-finished project by <a href="http://tague.me">Ethan McTague</a> |

--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ body {
     display: block;
 }
 .captionsb {
-    margin: 0.5ex;
+    margin: 0.25ex;
     font-size: 0.9em;
     display: none;
     font-weight: bold;
@@ -59,10 +59,9 @@ body {
     display: block;
 }
 #namesb {
-    margin: 0.5ex;
+    margin: 0.25ex;
     font-size: 1.1em;
     display: none;
-    font-weight: bold;
 	text-decoration: none;
     color: inherit;
 }

--- a/style.css
+++ b/style.css
@@ -49,6 +49,26 @@ body {
 .link .caption {
     display: block;
 }
+.captionsb {
+    margin: 0.5ex;
+    font-size: 0.9em;
+    display: none;
+    font-weight: bold;
+}
+.link .captionsb {
+    display: block;
+}
+#namesb {
+    margin: 0.5ex;
+    font-size: 1.1em;
+    display: none;
+    font-weight: bold;
+	text-decoration: none;
+    color: inherit;
+}
+.link #namesb {
+	display: block
+}
 #about {
     position: fixed;
     bottom: 4px;

--- a/style.css
+++ b/style.css
@@ -49,15 +49,6 @@ body {
 .link .caption {
     display: block;
 }
-.captionsb {
-    margin: 0.25ex;
-    font-size: 0.9em;
-    display: none;
-    font-weight: bold;
-}
-.link .captionsb {
-    display: block;
-}
 #namesb {
     margin: 0.25ex;
     font-size: 1.1em;


### PR DESCRIPTION
I decided to keep ineligibilty, but make it optional. Makes sense in the vim vs gvim case. Why do you need both when they are the same editor, just one has a gui?

Second best editor is quite simple, theres just some new text under the best editor, saying "Second best: <editor name> Click to read more" just like the above one does, but the editors name is a bit smaller.